### PR TITLE
updated the keyboard shortcuts button to 3

### DIFF
--- a/Toggle Function Keys.scpt
+++ b/Toggle Function Keys.scpt
@@ -21,7 +21,7 @@ if osver > 13.0 then
 		end repeat
 		
 		# "Keyboard Shortcuts..." Button
-		click button 1 of group 2 of scroll area 1 of group 1 of group 2 of splitter group 1 of group 1 of window 1
+		click button 3 of group 2 of scroll area 1 of group 1 of group 2 of splitter group 1 of group 1 of window 1
 		
 		repeat until sheet 1 of window 1 exists
 		end repeat


### PR DESCRIPTION
In Mac os sonoma (14.0) the button 1 and 2 are assigned to keyboard brightness hence updating the button to 3 to click on keyboard shortcuts

I am not aware if this a change that occurred in 13.0 or 14.0. 
 
Please let me know If I did something wrong I am very new to apple scripting